### PR TITLE
fix records request

### DIFF
--- a/tests/test_s04_leave_game.py
+++ b/tests/test_s04_leave_game.py
@@ -156,8 +156,8 @@ def validate_ok_response(res: requests.Response):
 def get_records(server, start: int = 0, max_items: int = 100) -> list:
     request = '/api/v1/game/records'
     header = {'content-type': 'application/json'}
-    params = {'start': start, 'maxItems': max_items}
-    res: requests.Response = server.request('GET', header, request, data=params)
+    url_params = {'start': start, 'maxItems': max_items}
+    res: requests.Response = server.request('GET', header, request, params=url_params)
     validate_ok_response(res)
     res_json: list = res.json()
     assert type(res_json) == list
@@ -347,7 +347,6 @@ def test_two_sequential_tribes_records(postgres_server: CppServer, map_id):
     compare(records, tribe_records)
 
 
-@pytest.mark.skip
 @pytest.mark.randomize(min_num=0, max_num=50, ncalls=3)
 @pytest.mark.randomize(min_num=0, max_num=100, ncalls=3)
 @pytest.mark.randomize(min_num=0, max_num=100, ncalls=3)


### PR DESCRIPTION
параметры должны оказаться в url (`/api/v1/game/records?start=0&maxItems=100`), а не в body

убрал скип теста, авторское решение проходит этот тест с правильно сформированным запросом