### PR TITLE
Add fixes for (a)sync_server and map_json tests

### DIFF
--- a/scripts/sprint1/async_server/run.sh
+++ b/scripts/sprint1/async_server/run.sh
@@ -5,5 +5,6 @@ REPO=${PWD}
 source ${REPO}/.venv/bin/activate
 
 export DELIVERY_APP=${REPO}/sprint1/problems/async_server/solution/build/bin/hello_async
+export COMMAND_RUN=${DELIVERY_APP}
 
 python3 -m pytest --rootdir=${REPO} --verbose --junitxml=results.xml cpp-backend-tests-practicum/tests/test_l03_hello_async.py

--- a/scripts/sprint1/map_json/run.sh
+++ b/scripts/sprint1/map_json/run.sh
@@ -5,7 +5,7 @@ REPO=${PWD}
 source ${REPO}/.venv/bin/activate
 
 export DELIVERY_APP=${REPO}/sprint1/problems/map_json/solution/build/bin/game_server
-
 export CONFIG_PATH=${REPO}/sprint1/problems/map_json/solution/data/config.json
+export COMMAND_RUN="${DELIVERY_APP} ${CONFIG_PATH}"
 
 python3 -m pytest --rootdir=${REPO} --verbose --junitxml=results.xml cpp-backend-tests-practicum/tests/test_l04_map_json.py

--- a/scripts/sprint1/sync_server/run.sh
+++ b/scripts/sprint1/sync_server/run.sh
@@ -5,5 +5,6 @@ REPO=${PWD}
 source ${REPO}/.venv/bin/activate
 
 export DELIVERY_APP=${REPO}/sprint1/problems/sync_server/solution/build/bin/hello
+export COMMAND_RUN=${DELIVERY_APP}
 
 python3 -m pytest --rootdir=${REPO} --verbose --junitxml=results.xml cpp-backend-tests-practicum/tests/test_l02_hello_beast.py


### PR DESCRIPTION
Тесты для sync_server, async_server и map_json вылетают с ошибкой

>           raise KeyError(key) from None
E           KeyError: 'COMMAND_RUN'
В код скриптов для их запуска добавлена строка, вида:

export COMMAND_RUN=${DELIVERY_APP} для серверов

или

export COMMAND_RUN="${DELIVERY_APP} ${CONFIG_PATH}" для map_json